### PR TITLE
responsivo

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -36,10 +36,6 @@
     color: #555;
 }
 
-form img{ /*login.html*/
-    width: 2vw;
-}
-
 .detalles{ /*products.html*/
     display: flex;
     flex-direction: column;
@@ -49,6 +45,17 @@ form img{ /*login.html*/
     margin-right: 20px;
     font-size: 1.5ex;
 }
+
+#products-container {
+    display: grid;
+    gap: 20px;
+}
+
+form img{ /*login.html*/
+    width: 2vw;
+}
+
+
 
 @media (max-width: 500px) { /*celulares*/ /*login.html*/
     /*header{
@@ -71,7 +78,25 @@ form img{ /*login.html*/
     }
 }
 
-@media (min-width: 501px) { /*tabletas y más grande*/ /*login.html*/
+#products-container {
+        grid-template-columns: 1fr; 
+    }
+    .producto {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+    .producto img {
+        width: 100%;
+        max-width: 250px;
+        margin: 0 auto 15px auto;
+    }
+    .detalles {
+        align-items: flex-start;
+        margin-top: 10px;
+    }
+
+
+@media (min-width: 501px) and (max-width: 1024px) { /*Tableta en Modo Vertical*/ /*login.html*/
     .container-login{
         width: 50%;
         
@@ -102,5 +127,17 @@ form img{ /*login.html*/
         margin-left: 37%;
         overflow: hidden;
         font-size: 1.5vw;
+    }
+}
+
+#products-container {
+        grid-template-columns: repeat(2, 1fr); /* 2 productos por fila */
+    }
+
+
+@media (min-width: 1025px) {
+    /* PRODUCTS */
+    #products-container {
+        grid-template-columns: repeat(4, 1fr);
     }
 }


### PR DESCRIPTION
Listado de productos se adapta a la pantalla de tablet en modo vertical. 

En esta resolución tenemos configurado que se muestren dos productos por fila. Esto lo logramos usando CSS Grid en #products-container, donde definimos grid-template-columns: repeat(2, 1fr) para pantallas entre 501 y 1024px. 

Usamos media queries para indicarle a CSS que hacer segun el tamaño de pantalla. En este caso, la regla para tablet vertical activa la grilla de dos columnas, mientras que en escritorio son cuatro y en celular uno solo. 

De esta manera, nos aseguramos que el listado de productos sea legible y estético en diferentes distintivos, así mejorando la experiencia del usuario.